### PR TITLE
Test different label configs

### DIFF
--- a/.github/workflows/labeler-predict.yml
+++ b/.github/workflows/labeler-predict.yml
@@ -37,9 +37,9 @@ jobs:
     with:
       model_cache_key: ${{ inputs.model_cache_key || github.repository }}
       issue_numbers: ${{ inputs.issue_numbers || github.event.issue.number }}
-      label_prefix: 'area-'
+      label_prefix: 'Area: '
       threshold: 0.40
-      default_label: 'needs-area-label'
+      default_label: 'Needs: ''Area'''
 
   predict-pulls:
     if: ${{ inputs.pull_numbers || github.event.number }}
@@ -49,6 +49,6 @@ jobs:
     with:
       model_cache_key: ${{ inputs.model_cache_key || github.repository }}
       pull_numbers: ${{ inputs.pull_numbers || github.event.number }}
-      label_prefix: 'area-'
+      label_prefix: 'Area: '
       threshold: 0.40
-      default_label: 'needs-area-label'
+      default_label: 'Needs: ''Area'''

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -44,7 +44,7 @@ jobs:
       github_token: ${{ inputs.github_token || github.token }}
       repository: ${{ inputs.repository || github.repository }}
       data_cache_key: ${{ inputs.cache_key_suffix }}
-      label_prefix: 'area-'
+      label_prefix: 'Area: '
 
   labeler-train-issues:
     needs: labeler-download-issues
@@ -64,7 +64,7 @@ jobs:
       github_token: ${{ github.token }}
       repository: ${{ inputs.repository || github.repository }}
       model_cache_key: ${{ inputs.cache_key_suffix || github.repository }}
-      label_prefix: 'area-'
+      label_prefix: 'Area: '
       threshold: 0.40
 
   labeler-download-pulls:
@@ -77,7 +77,7 @@ jobs:
       github_token: ${{ inputs.github_token || github.token }}
       repository: ${{ inputs.repository || github.repository }}
       data_cache_key: ${{ inputs.cache_key_suffix }}
-      label_prefix: 'area-'
+      label_prefix: 'Area: '
 
   labeler-train-pulls:
     needs: labeler-download-pulls
@@ -97,5 +97,5 @@ jobs:
       github_token: ${{ github.token }}
       repository: ${{ inputs.repository || github.repository }}
       model_cache_key: ${{ inputs.cache_key_suffix || github.repository }}
-      label_prefix: 'area-'
+      label_prefix: 'Area: '
       threshold: 0.40


### PR DESCRIPTION
This uses an `"Area: "` label prefix and a `"Needs: 'Area'"` default label for the `labeler-predict` and `labeler-train` workflows.